### PR TITLE
CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,114 @@
+cmake_minimum_required(VERSION 2.8)
+
+set(PACKAGE blunted2)
+
+set(VERSION_MAJOR 1)
+set(VERSION_MINOR 0)
+set(VERSION_PATCH 0)
+if(${VERSION_PATCH})
+   set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+else(${VERSION_PATCH})
+   set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
+endif(${VERSION_PATCH})
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules")
+
+project(blunted2)
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -Wall")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall")
+
+# Find needed libraries
+FIND_PACKAGE(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+
+FIND_PACKAGE(SDL REQUIRED)
+include_directories(${SDL_INCLUDE_DIR})
+
+FIND_PACKAGE(SDL_image REQUIRED)
+include_directories(${SDL_IMAGE_DIRS})
+
+FIND_PACKAGE(SDL_ttf REQUIRED)
+include_directories(${SDL_TTF_DIRS})
+
+FIND_PACKAGE(SDL_gfx REQUIRED)
+include_directories(${SDL_GFX_DIRS})
+
+FIND_PACKAGE(SDL_net REQUIRED)
+include_directories(${SDL_NET_INCLUDE_DIRS})
+
+FIND_PACKAGE(Boost REQUIRED COMPONENTS system thread signals filesystem)
+include_directories(${Boost_INCLUDE_DIR})
+
+FIND_PACKAGE(SGE REQUIRED)
+include_directories(${SGE_INCLUDE_DIR})
+
+FIND_PACKAGE(OpenAL REQUIRED)
+include_directories(${OPENAL_INCLUDE_DIR})
+
+
+include_directories(${PROJECT_SOURCE_DIR}/src)
+
+# Include the sources
+include(sources.cmake)
+
+# Compile it as multiple static libraries
+add_library(baselib OBJECT ${BASE_SOURCES} ${BASE_HEADERS})
+add_library(systemscommonlib OBJECT ${SYSTEMS_COMMON_SOURCES} 
+   ${SYSTEMS_COMMON_HEADERS})
+add_library(systemsgraphicslib OBJECT ${SYSTEMS_GRAPHICS_SOURCES} 
+   ${SYSTEMS_GRAPHICS_HEADERS})
+#add_library(systemsphysicslib OBJECT ${SYSTEMS_PHYSICS_SOURCES}
+#   ${SYSTEMS_PHYSICS_HEADERS})
+add_library(systemsaudiolib OBJECT ${SYSTEMS_AUDIO_SOURCES} 
+   ${SYSTEMS_AUDIO_HEADERS})
+add_library(loaderslib OBJECT ${LOADERS_SOURCES} ${LOADERS_HEADERS})
+add_library(typeslib OBJECT ${TYPES_SOURCES} ${TYPES_HEADERS})
+add_library(frameworklib OBJECT ${FRAMEWORK_SOURCES} ${FRAMEWORK_HEADERS})
+add_library(scenelib OBJECT ${SCENE_SOURCES} ${SCENE_HEADERS})
+add_library(managerslib OBJECT ${MANAGERS_SOURCES} ${MANAGERS_HEADERS})
+add_library(utilslib OBJECT ${UTILS_SOURCES} ${UTILS_HEADERS})
+add_library(gui2lib OBJECT ${UTILS_GUI2_SOURCES} ${UTILS_GUI2_HEADERS})
+
+set(OWN_LIBRARIES $<TARGET_OBJECTS:baselib> $<TARGET_OBJECTS:systemscommonlib>
+   $<TARGET_OBJECTS:systemsgraphicslib> 
+   #$<TARGET_OBJECTS:systemsphysicslib>
+   $<TARGET_OBJECTS:systemsaudiolib> $<TARGET_OBJECTS:loaderslib>
+   $<TARGET_OBJECTS:typeslib> $<TARGET_OBJECTS:frameworklib> 
+   $<TARGET_OBJECTS:scenelib> $<TARGET_OBJECTS:managerslib>
+   $<TARGET_OBJECTS:utilslib> $<TARGET_OBJECTS:gui2lib>)
+
+# Join all created static libraries into the single static or share one.
+
+# For shared library, uncomment bellow:
+
+#set_property(TARGET baselib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET systemscommonlib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET systemsgraphicslib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET systemsphysicslib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET systemsaudiolib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET loaderslib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET typeslib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET frameworklib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET scenelib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET managerslib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET utilslib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#set_property(TARGET gui2lib PROPERTY POSITION_INDEPENDENT_CODE 1)
+#add_library(blunted2 SHARED ${CORE_SOURCES} ${CORE_HEADERS} ${OWN_LIBRARIES})
+
+#set_target_properties(blunted2 PROPERTIES VERSION ${VERSION}
+#   SOVERSION ${VERSION_MAJOR} )
+#add_library(blunted2 SHARED ${CORE_SOURCES} ${LIBS_SOURCES} ${CORE_HEADERS}
+#   ${LIBS_HEADERS} ${OWN_LIBRARIES})
+
+# For static library.
+add_library(blunted2 ${CORE_SOURCES} ${LIBS_SOURCES} ${CORE_HEADERS}
+   ${LIBS_HEADERS} ${OWN_LIBRARIES})
+
+# FIXME: its copying all .cpp too, but I'm too lazy to set them all again.
+#        ideally, headers should be at a include directory, separated from
+#        the sources, but that will be too disruptive for the current folder
+#        organization.
+install(DIRECTORY ./src/ DESTINATION include/blunted2)
+install(TARGETS blunted2 DESTINATION lib)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,27 +52,32 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 # Include the sources
 include(sources.cmake)
 
-# Compile it as multiple static libraries
-add_library(baselib OBJECT ${BASE_SOURCES} ${BASE_HEADERS})
+# Compile it as multiple static libraries (note: not compiling physics,
+# as not used by gameplayfootball)
+add_library(baselib OBJECT ${BASE_SOURCES} ${BASE_HEADERS}
+   ${BASE_GEOMETRY_HEADERS} ${BASE_MATH_HEADERS})
 add_library(systemscommonlib OBJECT ${SYSTEMS_COMMON_SOURCES} 
    ${SYSTEMS_COMMON_HEADERS})
 add_library(systemsgraphicslib OBJECT ${SYSTEMS_GRAPHICS_SOURCES} 
-   ${SYSTEMS_GRAPHICS_HEADERS})
-#add_library(systemsphysicslib OBJECT ${SYSTEMS_PHYSICS_SOURCES}
-#   ${SYSTEMS_PHYSICS_HEADERS})
+   ${SYSTEMS_GRAPHICS_HEADERS} ${SYSTEMS_GRAPHICS_OBJECTS_HEADERS}
+   ${SYSTEMS_GRAPHICS_RESOURCES_HEADERS} ${SYSTEMS_GRAPHICS_RENDERING_HEADERS})
 add_library(systemsaudiolib OBJECT ${SYSTEMS_AUDIO_SOURCES} 
-   ${SYSTEMS_AUDIO_HEADERS})
+   ${SYSTEMS_AUDIO_HEADERS} ${SYSTEMS_AUDIO_OBJECTS_HEADERS}
+   ${SYSTEMS_AUDIO_RESOURCES_HEADERS} ${SYSTEMS_AUDIO_RENDERING_HEADERS})
 add_library(loaderslib OBJECT ${LOADERS_SOURCES} ${LOADERS_HEADERS})
 add_library(typeslib OBJECT ${TYPES_SOURCES} ${TYPES_HEADERS})
 add_library(frameworklib OBJECT ${FRAMEWORK_SOURCES} ${FRAMEWORK_HEADERS})
-add_library(scenelib OBJECT ${SCENE_SOURCES} ${SCENE_HEADERS})
+add_library(scenelib OBJECT ${SCENE_SOURCES} ${SCENE_HEADERS}
+   ${SCENE2D_HEADERS} ${SCENE3D_HEADERS} ${SCENE_OBJECTS_HEADERS}
+   ${SCENE_RESOURCES_HEADERS})
 add_library(managerslib OBJECT ${MANAGERS_SOURCES} ${MANAGERS_HEADERS})
-add_library(utilslib OBJECT ${UTILS_SOURCES} ${UTILS_HEADERS})
-add_library(gui2lib OBJECT ${UTILS_GUI2_SOURCES} ${UTILS_GUI2_HEADERS})
+add_library(utilslib OBJECT ${UTILS_SOURCES} ${UTILS_HEADERS}
+   ${UTILS_EXT_HEADERS})
+add_library(gui2lib OBJECT ${UTILS_GUI2_SOURCES} ${UTILS_GUI2_HEADERS}
+   ${UTILS_GUI2_WIDGETS_HEADERS})
 
 set(OWN_LIBRARIES $<TARGET_OBJECTS:baselib> $<TARGET_OBJECTS:systemscommonlib>
    $<TARGET_OBJECTS:systemsgraphicslib> 
-   #$<TARGET_OBJECTS:systemsphysicslib>
    $<TARGET_OBJECTS:systemsaudiolib> $<TARGET_OBJECTS:loaderslib>
    $<TARGET_OBJECTS:typeslib> $<TARGET_OBJECTS:frameworklib> 
    $<TARGET_OBJECTS:scenelib> $<TARGET_OBJECTS:managerslib>
@@ -85,7 +90,6 @@ set(OWN_LIBRARIES $<TARGET_OBJECTS:baselib> $<TARGET_OBJECTS:systemscommonlib>
 #set_property(TARGET baselib PROPERTY POSITION_INDEPENDENT_CODE 1)
 #set_property(TARGET systemscommonlib PROPERTY POSITION_INDEPENDENT_CODE 1)
 #set_property(TARGET systemsgraphicslib PROPERTY POSITION_INDEPENDENT_CODE 1)
-#set_property(TARGET systemsphysicslib PROPERTY POSITION_INDEPENDENT_CODE 1)
 #set_property(TARGET systemsaudiolib PROPERTY POSITION_INDEPENDENT_CODE 1)
 #set_property(TARGET loaderslib PROPERTY POSITION_INDEPENDENT_CODE 1)
 #set_property(TARGET typeslib PROPERTY POSITION_INDEPENDENT_CODE 1)
@@ -99,16 +103,70 @@ set(OWN_LIBRARIES $<TARGET_OBJECTS:baselib> $<TARGET_OBJECTS:systemscommonlib>
 #set_target_properties(blunted2 PROPERTIES VERSION ${VERSION}
 #   SOVERSION ${VERSION_MAJOR} )
 #add_library(blunted2 SHARED ${CORE_SOURCES} ${LIBS_SOURCES} ${CORE_HEADERS}
-#   ${LIBS_HEADERS} ${OWN_LIBRARIES})
+#   ${ALL_LIBS_HEADERS} ${OWN_LIBRARIES})
 
 # For static library.
 add_library(blunted2 ${CORE_SOURCES} ${LIBS_SOURCES} ${CORE_HEADERS}
-   ${LIBS_HEADERS} ${OWN_LIBRARIES})
+   ${ALL_LIBS_HEADERS} ${OWN_LIBRARIES})
 
-# FIXME: its copying all .cpp too, but I'm too lazy to set them all again.
-#        ideally, headers should be at a include directory, separated from
-#        the sources, but that will be too disruptive for the current folder
-#        organization.
-install(DIRECTORY ./src/ DESTINATION include/blunted2)
+# Install our headers, keeping directory structure (if they are separated from
+# the sources would be easier, but separate them would be too disruptive to
+# merge on the original repository).
+install(FILES ${CORE_HEADERS} DESTINATION include/blunted2)
+install(FILES ${BASE_HEADERS} DESTINATION include/blunted2/base)
+install(FILES ${BASE_GEOMETRY_HEADERS} DESTINATION 
+   include/blunted2/base/geometry)
+install(FILES ${BASE_MATH_HEADERS} DESTINATION include/blunted2/base/math)
+
+install(FILES ${SYSTEMS_COMMON_HEADERS} DESTINATION include/blunted2/systems)
+
+install(FILES ${SYSTEMS_GRAPHICS_HEADERS} DESTINATION
+   include/blunted2/systems/graphics)
+install(FILES ${SYSTEMS_GRAPHICS_OBJECTS_HEADERS} DESTINATION
+   include/blunted2/systems/graphics/objects)
+install(FILES ${SYSTEMS_GRAPHICS_RESOURCES_HEADERS} DESTINATION
+   include/blunted2/systems/graphics/resources)
+install(FILES ${SYSTEMS_GRAPHICS_RENDERING_HEADERS} DESTINATION
+   include/blunted2/systems/graphics/rendering)
+
+install(FILES ${SYSTEMS_AUDIO_HEADERS} DESTINATION
+   include/blunted2/systems/audio)
+install(FILES ${SYSTEMS_AUDIO_OBJECTS_HEADERS} DESTINATION
+   include/blunted2/systems/audio/objects)
+install(FILES ${SYSTEMS_AUDIO_RESOURCES_HEADERS} DESTINATION
+   include/blunted2/systems/audio/resources)
+install(FILES ${SYSTEMS_AUDIO_RENDERING_HEADERS} DESTINATION
+   include/blunted2/systems/audio/rendering)
+
+install(FILES ${LOADERS_HEADERS} DESTINATION include/blunted2/loaders)
+install(FILES ${TYPES_HEADERS} DESTINATION include/blunted2/types)
+install(FILES ${FRAMEWORK_HEADERS} DESTINATION include/blunted2/framework)
+install(FILES ${MANAGERS_HEADERS} DESTINATION include/blunted2/managers)
+
+install(FILES ${SCENE_HEADERS} DESTINATION include/blunted2/scene)
+install(FILES ${SCENE2D_HEADERS} DESTINATION include/blunted2/scene/scene2d) 
+install(FILES ${SCENE3D_HEADERS} DESTINATION include/blunted2/scene/scene3d) 
+install(FILES ${SCENE_OBJECTS_HEADERS} DESTINATION 
+   include/blunted2/scene/objects)
+install(FILES ${SCENE_RESOURCES_HEADERS} DESTINATION 
+   include/blunted2/scene/resources)
+
+install(FILES ${UTILS_HEADERS} DESTINATION include/blunted2/utils)
+install(FILES ${UTILS_EXT_HEADERS} DESTINATION 
+   include/blunted2/utils/animationextensions)
+
+install(FILES ${UTILS_GUI2_HEADERS} DESTINATION
+   include/blunted2/utils/gui2) 
+install(FILES ${UTILS_GUI2_WIDGETS_HEADERS} DESTINATION
+      include/blunted2/utils/gui2/widgets)
+
+install(FILES ${LIBS_HEADERS} DESTINATION include/blunted2/libs)
+install(FILES ${LIBS_FASTEVENTS_HEADERS} DESTINATION
+   include/blunted2/libs/fastevents)
+install(FILES ${LIBS_SQLITE3_HEADERS} DESTINATION
+   include/blunted2/libs/sqlite3) 
+install(FILES ${LIBS_GLEE_HEADERS} DESTINATION include/blunted2/libs/glee)
+
+# Install the library itself.
 install(TARGETS blunted2 DESTINATION lib)
 

--- a/CMakeModules/FindPackageHandleStandardArgs.cmake
+++ b/CMakeModules/FindPackageHandleStandardArgs.cmake
@@ -1,0 +1,296 @@
+# FIND_PACKAGE_HANDLE_STANDARD_ARGS(<name> ... )
+#
+# This function is intended to be used in FindXXX.cmake modules files.
+# It handles the REQUIRED, QUIET and version-related arguments to FIND_PACKAGE().
+# It also sets the <UPPERCASED_NAME>_FOUND variable.
+# The package is considered found if all variables <var1>... listed contain
+# valid results, e.g. valid filepaths.
+#
+# There are two modes of this function. The first argument in both modes is
+# the name of the Find-module where it is called (in original casing).
+#
+# The first simple mode looks like this:
+#    FIND_PACKAGE_HANDLE_STANDARD_ARGS(<name> (DEFAULT_MSG|"Custom failure message") <var1>...<varN> )
+# If the variables <var1> to <varN> are all valid, then <UPPERCASED_NAME>_FOUND
+# will be set to TRUE.
+# If DEFAULT_MSG is given as second argument, then the function will generate
+# itself useful success and error messages. You can also supply a custom error message
+# for the failure case. This is not recommended.
+#
+# The second mode is more powerful and also supports version checking:
+#    FIND_PACKAGE_HANDLE_STANDARD_ARGS(NAME [REQUIRED_VARS <var1>...<varN>]
+#                                           [VERSION_VAR   <versionvar>]
+#                                           [HANDLE_COMPONENTS]
+#                                           [CONFIG_MODE]
+#                                           [FAIL_MESSAGE "Custom failure message"] )
+#
+# As above, if <var1> through <varN> are all valid, <UPPERCASED_NAME>_FOUND
+# will be set to TRUE.
+# After REQUIRED_VARS the variables which are required for this package are listed.
+# Following VERSION_VAR the name of the variable can be specified which holds
+# the version of the package which has been found. If this is done, this version
+# will be checked against the (potentially) specified required version used
+# in the find_package() call. The EXACT keyword is also handled. The default
+# messages include information about the required version and the version
+# which has been actually found, both if the version is ok or not.
+# If the package supports components, use the HANDLE_COMPONENTS option to enable
+# handling them. In this case, find_package_handle_standard_args() will report
+# which components have been found and which are missing, and the <NAME>_FOUND
+# variable will be set to FALSE if any of the required components (i.e. not the
+# ones listed after OPTIONAL_COMPONENTS) are missing.
+# Use the option CONFIG_MODE if your FindXXX.cmake module is a wrapper for
+# a find_package(... NO_MODULE) call.  In this case VERSION_VAR will be set
+# to <NAME>_VERSION and the macro will automatically check whether the
+# Config module was found.
+# Via FAIL_MESSAGE a custom failure message can be specified, if this is not
+# used, the default message will be displayed.
+#
+# Example for mode 1:
+#
+#    FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibXml2  DEFAULT_MSG  LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
+#
+# LibXml2 is considered to be found, if both LIBXML2_LIBRARY and
+# LIBXML2_INCLUDE_DIR are valid. Then also LIBXML2_FOUND is set to TRUE.
+# If it is not found and REQUIRED was used, it fails with FATAL_ERROR,
+# independent whether QUIET was used or not.
+# If it is found, success will be reported, including the content of <var1>.
+# On repeated Cmake runs, the same message won't be printed again.
+#
+# Example for mode 2:
+#
+#    FIND_PACKAGE_HANDLE_STANDARD_ARGS(BISON  REQUIRED_VARS BISON_EXECUTABLE
+#                                             VERSION_VAR BISON_VERSION)
+# In this case, BISON is considered to be found if the variable(s) listed
+# after REQUIRED_VAR are all valid, i.e. BISON_EXECUTABLE in this case.
+# Also the version of BISON will be checked by using the version contained
+# in BISON_VERSION.
+# Since no FAIL_MESSAGE is given, the default messages will be printed.
+#
+# Another example for mode 2:
+#
+#    FIND_PACKAGE(Automoc4 QUIET NO_MODULE HINTS /opt/automoc4)
+#    FIND_PACKAGE_HANDLE_STANDARD_ARGS(Automoc4  CONFIG_MODE)
+# In this case, FindAutmoc4.cmake wraps a call to FIND_PACKAGE(Automoc4 NO_MODULE)
+# and adds an additional search directory for automoc4.
+# The following FIND_PACKAGE_HANDLE_STANDARD_ARGS() call produces a proper
+# success/error message.
+
+#=============================================================================
+# Copyright 2007-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+INCLUDE(FindPackageMessage)
+INCLUDE(CMakeParseArguments)
+
+# internal helper macro
+MACRO(_FPHSA_FAILURE_MESSAGE _msg)
+  IF (${_NAME}_FIND_REQUIRED)
+    MESSAGE(FATAL_ERROR "${_msg}")
+  ELSE (${_NAME}_FIND_REQUIRED)
+    IF (NOT ${_NAME}_FIND_QUIETLY)
+      MESSAGE(STATUS "${_msg}")
+    ENDIF (NOT ${_NAME}_FIND_QUIETLY)
+  ENDIF (${_NAME}_FIND_REQUIRED)
+ENDMACRO(_FPHSA_FAILURE_MESSAGE _msg)
+
+
+# internal helper macro to generate the failure message when used in CONFIG_MODE:
+MACRO(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
+  # <name>_CONFIG is set, but FOUND is false, this means that some other of the REQUIRED_VARS was not found:
+  IF(${_NAME}_CONFIG)
+    _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: missing: ${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})")
+  ELSE(${_NAME}_CONFIG)
+    # If _CONSIDERED_CONFIGS is set, the config-file has been found, but no suitable version.
+    # List them all in the error message:
+    IF(${_NAME}_CONSIDERED_CONFIGS)
+      SET(configsText "")
+      LIST(LENGTH ${_NAME}_CONSIDERED_CONFIGS configsCount)
+      MATH(EXPR configsCount "${configsCount} - 1")
+      FOREACH(currentConfigIndex RANGE ${configsCount})
+        LIST(GET ${_NAME}_CONSIDERED_CONFIGS ${currentConfigIndex} filename)
+        LIST(GET ${_NAME}_CONSIDERED_VERSIONS ${currentConfigIndex} version)
+        SET(configsText "${configsText}    ${filename} (version ${version})\n")
+      ENDFOREACH(currentConfigIndex)
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:\n${configsText}")
+
+    ELSE(${_NAME}_CONSIDERED_CONFIGS)
+      # Simple case: No Config-file was found at all:
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}")
+    ENDIF(${_NAME}_CONSIDERED_CONFIGS)
+  ENDIF(${_NAME}_CONFIG)
+ENDMACRO(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
+
+
+FUNCTION(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
+
+# set up the arguments for CMAKE_PARSE_ARGUMENTS and check whether we are in
+# new extended or in the "old" mode:
+  SET(options CONFIG_MODE HANDLE_COMPONENTS)
+  SET(oneValueArgs FAIL_MESSAGE VERSION_VAR)
+  SET(multiValueArgs REQUIRED_VARS)
+  SET(_KEYWORDS_FOR_EXTENDED_MODE  ${options} ${oneValueArgs} ${multiValueArgs} )
+  LIST(FIND _KEYWORDS_FOR_EXTENDED_MODE "${_FIRST_ARG}" INDEX)
+
+  IF(${INDEX} EQUAL -1)
+    SET(FPHSA_FAIL_MESSAGE ${_FIRST_ARG})
+    SET(FPHSA_REQUIRED_VARS ${ARGN})
+    SET(FPHSA_VERSION_VAR)
+  ELSE(${INDEX} EQUAL -1)
+
+    CMAKE_PARSE_ARGUMENTS(FPHSA "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${_FIRST_ARG} ${ARGN})
+
+    IF(FPHSA_UNPARSED_ARGUMENTS)
+      MESSAGE(FATAL_ERROR "Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS(): \"${FPHSA_UNPARSED_ARGUMENTS}\"")
+    ENDIF(FPHSA_UNPARSED_ARGUMENTS)
+
+    IF(NOT FPHSA_FAIL_MESSAGE)
+      SET(FPHSA_FAIL_MESSAGE  "DEFAULT_MSG")
+    ENDIF(NOT FPHSA_FAIL_MESSAGE)
+  ENDIF(${INDEX} EQUAL -1)
+
+# now that we collected all arguments, process them
+
+  IF("${FPHSA_FAIL_MESSAGE}" STREQUAL "DEFAULT_MSG")
+    SET(FPHSA_FAIL_MESSAGE "Could NOT find ${_NAME}")
+  ENDIF("${FPHSA_FAIL_MESSAGE}" STREQUAL "DEFAULT_MSG")
+
+  # In config-mode, we rely on the variable <package>_CONFIG, which is set by find_package()
+  # when it successfully found the config-file, including version checking:
+  IF(FPHSA_CONFIG_MODE)
+    LIST(INSERT FPHSA_REQUIRED_VARS 0 ${_NAME}_CONFIG)
+    LIST(REMOVE_DUPLICATES FPHSA_REQUIRED_VARS)
+    SET(FPHSA_VERSION_VAR ${_NAME}_VERSION)
+  ENDIF(FPHSA_CONFIG_MODE)
+
+  IF(NOT FPHSA_REQUIRED_VARS)
+    MESSAGE(FATAL_ERROR "No REQUIRED_VARS specified for FIND_PACKAGE_HANDLE_STANDARD_ARGS()")
+  ENDIF(NOT FPHSA_REQUIRED_VARS)
+
+  LIST(GET FPHSA_REQUIRED_VARS 0 _FIRST_REQUIRED_VAR)
+
+  STRING(TOUPPER ${_NAME} _NAME_UPPER)
+  STRING(TOLOWER ${_NAME} _NAME_LOWER)
+
+  # collect all variables which were not found, so they can be printed, so the
+  # user knows better what went wrong (#6375)
+  SET(MISSING_VARS "")
+  SET(DETAILS "")
+  SET(${_NAME_UPPER}_FOUND TRUE)
+  # check if all passed variables are valid
+  FOREACH(_CURRENT_VAR ${FPHSA_REQUIRED_VARS})
+    IF(NOT ${_CURRENT_VAR})
+      SET(${_NAME_UPPER}_FOUND FALSE)
+      SET(MISSING_VARS "${MISSING_VARS} ${_CURRENT_VAR}")
+    ELSE(NOT ${_CURRENT_VAR})
+      SET(DETAILS "${DETAILS}[${${_CURRENT_VAR}}]")
+    ENDIF(NOT ${_CURRENT_VAR})
+  ENDFOREACH(_CURRENT_VAR)
+
+  # component handling
+  UNSET(FOUND_COMPONENTS_MSG)
+  UNSET(MISSING_COMPONENTS_MSG)
+
+  IF(FPHSA_HANDLE_COMPONENTS)
+    FOREACH(comp ${${_NAME}_FIND_COMPONENTS})
+      IF(${_NAME}_${comp}_FOUND)
+
+        IF(NOT DEFINED FOUND_COMPONENTS_MSG)
+          SET(FOUND_COMPONENTS_MSG "found components: ")
+        ENDIF()
+        SET(FOUND_COMPONENTS_MSG "${FOUND_COMPONENTS_MSG} ${comp}")
+
+      ELSE()
+
+        IF(NOT DEFINED MISSING_COMPONENTS_MSG)
+          SET(MISSING_COMPONENTS_MSG "missing components: ")
+        ENDIF()
+        SET(MISSING_COMPONENTS_MSG "${MISSING_COMPONENTS_MSG} ${comp}")
+
+        IF(${_NAME}_FIND_REQUIRED_${comp})
+          SET(${_NAME_UPPER}_FOUND FALSE)
+          SET(MISSING_VARS "${MISSING_VARS} ${comp}")
+        ENDIF()
+
+      ENDIF()
+    ENDFOREACH(comp)
+    SET(COMPONENT_MSG "${FOUND_COMPONENTS_MSG} ${MISSING_COMPONENTS_MSG}")
+    SET(DETAILS "${DETAILS}[c${COMPONENT_MSG}]")
+  ENDIF(FPHSA_HANDLE_COMPONENTS)
+
+  # version handling:
+  SET(VERSION_MSG "")
+  SET(VERSION_OK TRUE)
+  SET(VERSION ${${FPHSA_VERSION_VAR}} )
+  IF (${_NAME}_FIND_VERSION)
+
+    IF(VERSION)
+
+      IF(${_NAME}_FIND_VERSION_EXACT)       # exact version required
+        IF (NOT "${${_NAME}_FIND_VERSION}" VERSION_EQUAL "${VERSION}")
+          SET(VERSION_MSG "Found unsuitable version \"${VERSION}\", but required is exact version \"${${_NAME}_FIND_VERSION}\"")
+          SET(VERSION_OK FALSE)
+        ELSE (NOT "${${_NAME}_FIND_VERSION}" VERSION_EQUAL "${VERSION}")
+          SET(VERSION_MSG "(found suitable exact version \"${VERSION}\")")
+        ENDIF (NOT "${${_NAME}_FIND_VERSION}" VERSION_EQUAL "${VERSION}")
+
+      ELSE(${_NAME}_FIND_VERSION_EXACT)     # minimum version specified:
+        IF ("${${_NAME}_FIND_VERSION}" VERSION_GREATER "${VERSION}")
+          SET(VERSION_MSG "Found unsuitable version \"${VERSION}\", but required is at least \"${${_NAME}_FIND_VERSION}\"")
+          SET(VERSION_OK FALSE)
+        ELSE ("${${_NAME}_FIND_VERSION}" VERSION_GREATER "${VERSION}")
+          SET(VERSION_MSG "(found suitable version \"${VERSION}\", required is \"${${_NAME}_FIND_VERSION}\")")
+        ENDIF ("${${_NAME}_FIND_VERSION}" VERSION_GREATER "${VERSION}")
+      ENDIF(${_NAME}_FIND_VERSION_EXACT)
+
+    ELSE(VERSION)
+
+      # if the package was not found, but a version was given, add that to the output:
+      IF(${_NAME}_FIND_VERSION_EXACT)
+         SET(VERSION_MSG "(Required is exact version \"${${_NAME}_FIND_VERSION}\")")
+      ELSE(${_NAME}_FIND_VERSION_EXACT)
+         SET(VERSION_MSG "(Required is at least version \"${${_NAME}_FIND_VERSION}\")")
+      ENDIF(${_NAME}_FIND_VERSION_EXACT)
+
+    ENDIF(VERSION)
+  ELSE (${_NAME}_FIND_VERSION)
+    IF(VERSION)
+      SET(VERSION_MSG "(found version \"${VERSION}\")")
+    ENDIF(VERSION)
+  ENDIF (${_NAME}_FIND_VERSION)
+
+  IF(VERSION_OK)
+    SET(DETAILS "${DETAILS}[v${VERSION}(${${_NAME}_FIND_VERSION})]")
+  ELSE(VERSION_OK)
+    SET(${_NAME_UPPER}_FOUND FALSE)
+  ENDIF(VERSION_OK)
+
+
+  # print the result:
+  IF (${_NAME_UPPER}_FOUND)
+    FIND_PACKAGE_MESSAGE(${_NAME} "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}" "${DETAILS}")
+  ELSE (${_NAME_UPPER}_FOUND)
+
+    IF(FPHSA_CONFIG_MODE)
+      _FPHSA_HANDLE_FAILURE_CONFIG_MODE()
+    ELSE(FPHSA_CONFIG_MODE)
+      IF(NOT VERSION_OK)
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (found ${${_FIRST_REQUIRED_VAR}})")
+      ELSE(NOT VERSION_OK)
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} (missing: ${MISSING_VARS}) ${VERSION_MSG}")
+      ENDIF(NOT VERSION_OK)
+    ENDIF(FPHSA_CONFIG_MODE)
+
+  ENDIF (${_NAME_UPPER}_FOUND)
+
+  SET(${_NAME_UPPER}_FOUND ${${_NAME_UPPER}_FOUND} PARENT_SCOPE)
+
+ENDFUNCTION(FIND_PACKAGE_HANDLE_STANDARD_ARGS _FIRST_ARG)

--- a/CMakeModules/FindSDL_gfx.cmake
+++ b/CMakeModules/FindSDL_gfx.cmake
@@ -1,0 +1,68 @@
+# Locate SDL_gfx library
+# This module defines
+# SDL_GFX_LIBRARIES, the name of the library to link against
+# SDL_GFX_FOUND, if false, do not try to link to SDL_GFX
+# 
+# SDL_GFX_INCLUDE_DIRS, where to find sgeconfig.h
+#
+# $SDL_GFXDIR - enviroment variable
+#
+# Created by Farrer. This was influenced by the FindSDL_image.cmake module.
+
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+FIND_PATH(SDL_GFX_INCLUDE_DIRS NAMES SDL_gfxPrimitives.h
+  HINTS
+  $ENV{SDL_GFXDIR}
+  PATH_SUFFIXES include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/include/sge
+  /usr/local/include/SDL
+  /usr/include/sge
+  /usr/include/SDL
+  /usr/local/include
+  /usr/include
+  /sw/include/sge # Fink
+  /sw/include/SDL
+  /sw/include
+  /opt/local/include/sge # DarwinPorts
+  /opt/local/include/SDL
+  /opt/local/include
+  /opt/csw/include/sge # Blastwave
+  /opt/csw/include/SDL # Blastwave
+  /opt/csw/include 
+  /opt/include/sge
+  /opt/include
+)
+
+FIND_LIBRARY(SDL_GFX_LIBRARIES 
+   NAMES SDL_gfx
+  HINTS
+  $ENV{SDL_GFXDIR}
+  PATH_SUFFIXES lib64 lib
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /usr
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
+)
+
+INCLUDE(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL_gfx
+   REQUIRED_VARS SDL_GFX_LIBRARIES SDL_GFX_INCLUDE_DIRS)

--- a/CMakeModules/FindSGE.cmake
+++ b/CMakeModules/FindSGE.cmake
@@ -1,0 +1,68 @@
+# Locate SGE library
+# This module defines
+# SGE_LIBRARY, the name of the library to link against
+# SGE_FOUND, if false, do not try to link to SGE
+# 
+# SGE_INCLUDE_DIR, where to find sgeconfig.h
+#
+# $SGEDIR - enviroment variable
+#
+# Created by Farrer. This was influenced by the FindSDL_image.cmake module.
+
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+FIND_PATH(SGE_INCLUDE_DIR NAMES sge.h
+  HINTS
+  $ENV{SGEDIR}
+  PATH_SUFFIXES include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/include/sge
+  /usr/local/include/SDL
+  /usr/include/sge
+  /usr/include/SDL
+  /usr/local/include
+  /usr/include
+  /sw/include/sge # Fink
+  /sw/include/SDL
+  /sw/include
+  /opt/local/include/sge # DarwinPorts
+  /opt/local/include/SDL
+  /opt/local/include
+  /opt/csw/include/sge # Blastwave
+  /opt/csw/include/SDL # Blastwave
+  /opt/csw/include 
+  /opt/include/sge
+  /opt/include
+)
+
+FIND_LIBRARY(SGE_LIBRARY 
+   NAMES SGE
+  HINTS
+  $ENV{SGEDIR}
+  PATH_SUFFIXES lib64 lib
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /usr
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
+)
+
+INCLUDE(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SGE
+   REQUIRED_VARS SGE_LIBRARY SGE_INCLUDE_DIR)

--- a/sources.cmake
+++ b/sources.cmake
@@ -4,11 +4,17 @@ set(BASE_HEADERS
    src/base/utils.hpp
    src/base/properties.hpp
    src/base/sdl_surface.hpp
+)
+
+set(BASE_GEOMETRY_HEADERS
    src/base/geometry/aabb.hpp
    src/base/geometry/trianglemeshutils.hpp
    src/base/geometry/plane.hpp
    src/base/geometry/triangle.hpp
    src/base/geometry/line.hpp
+)
+
+set(BASE_MATH_HEADERS
    src/base/math/quaternion.hpp
    src/base/math/matrix3.hpp
    src/base/math/matrix4.hpp
@@ -47,18 +53,27 @@ set(SYSTEMS_COMMON_SOURCES
 
 set(SYSTEMS_GRAPHICS_HEADERS
    src/systems/graphics/graphics_task.hpp
+   src/systems/graphics/graphics_scene.hpp
+   src/systems/graphics/graphics_object.hpp
+   src/systems/graphics/graphics_system.hpp
+)
+
+set(SYSTEMS_GRAPHICS_OBJECTS_HEADERS
    src/systems/graphics/objects/graphics_overlay2d.hpp
    src/systems/graphics/objects/graphics_camera.hpp
    src/systems/graphics/objects/graphics_light.hpp
    src/systems/graphics/objects/graphics_geometry.hpp
-   src/systems/graphics/graphics_scene.hpp
-   src/systems/graphics/graphics_object.hpp
+)
+
+set(SYSTEMS_GRAPHICS_RESOURCES_HEADERS
    src/systems/graphics/resources/vertexbuffer.hpp
    src/systems/graphics/resources/texture.hpp
+)
+
+set(SYSTEMS_GRAPHICS_RENDERING_HEADERS
    src/systems/graphics/rendering/interface_renderer3d.hpp
    src/systems/graphics/rendering/opengl_renderer3d.hpp
    src/systems/graphics/rendering/r3d_messages.hpp
-   src/systems/graphics/graphics_system.hpp
 )
 
 set(SYSTEMS_GRAPHICS_SOURCES
@@ -99,16 +114,25 @@ set(SYSTEMS_PHYSICS_SOURCES
    src/systems/physics/resources/vertexbuffer.cpp
 )
 
-set(SYSTEMS_AUDIO_HEADERS
+set(SYSTEMS_AUDIO_OBJECTS_HEADERS
    src/systems/audio/objects/audio_sound.hpp
    src/systems/audio/objects/audio_audioreceiver.hpp
+)
+
+set(SYSTEMS_AUDIO_HEADERS
    src/systems/audio/audio_object.hpp
-   src/systems/audio/resources/audio_soundbuffer.hpp
    src/systems/audio/audio_scene.hpp
+   src/systems/audio/audio_system.hpp
+)
+
+set(SYSTEMS_AUDIO_RESOURCES_HEADERS
+   src/systems/audio/resources/audio_soundbuffer.hpp
+)
+
+set(SYSTEMS_AUDIO_RENDERING_HEADERS
    src/systems/audio/rendering/openal_renderer.hpp
    src/systems/audio/rendering/interface_audiorenderer.hpp
    src/systems/audio/rendering/audio_messages.hpp
-   src/systems/audio/audio_system.hpp
 )
 
 set(SYSTEMS_AUDIO_SOURCES
@@ -175,9 +199,16 @@ set(FRAMEWORK_SOURCES
 
 set(SCENE_HEADERS
    src/scene/scene.hpp
-   src/scene/scene2d/scene2d.hpp
+   src/scene/iscene.hpp
    src/scene/object.hpp
    src/scene/objectfactory.hpp
+)
+
+set(SCENE2D_HEADERS
+   src/scene/scene2d/scene2d.hpp
+)
+
+set(SCENE_OBJECTS_HEADERS
    src/scene/objects/skybox.hpp
    src/scene/objects/geometry.hpp
    src/scene/objects/light.hpp
@@ -186,9 +217,14 @@ set(SCENE_HEADERS
    src/scene/objects/joint.hpp
    src/scene/objects/image2d.hpp
    src/scene/objects/camera.hpp
+)
+
+set(SCENE3D_HEADERS
    src/scene/scene3d/scene3d.hpp
    src/scene/scene3d/node.hpp
-   src/scene/iscene.hpp
+)
+
+set(SCENE_RESOURCES_HEADERS
    src/scene/resources/geometrydata.hpp
    src/scene/resources/soundbuffer.hpp
    src/scene/resources/surface.hpp
@@ -242,10 +278,13 @@ set(UTILS_HEADERS
    src/utils/orbitcamera.hpp
    src/utils/text2d.hpp
    src/utils/directoryparser.hpp
-   src/utils/animationextensions/animationextension.hpp
-   src/utils/animationextensions/footballanimationextension.hpp
    src/utils/threadhud.hpp
    src/utils/console.hpp
+)
+
+set(UTILS_EXT_HEADERS
+   src/utils/animationextensions/animationextension.hpp
+   src/utils/animationextensions/footballanimationextension.hpp
 )
 
 set(UTILS_SOURCES
@@ -264,6 +303,14 @@ set(UTILS_SOURCES
 
 set(UTILS_GUI2_HEADERS
    src/utils/gui2/events.hpp
+   src/utils/gui2/windowmanager.hpp
+   src/utils/gui2/page.hpp
+   src/utils/gui2/style.hpp
+   src/utils/gui2/guitask.hpp
+   src/utils/gui2/view.hpp
+)
+
+set(UTILS_GUI2_WIDGETS_HEADERS
    src/utils/gui2/widgets/slider.hpp
    src/utils/gui2/widgets/image.hpp
    src/utils/gui2/widgets/dialog.hpp
@@ -280,11 +327,6 @@ set(UTILS_GUI2_HEADERS
    src/utils/gui2/widgets/menu.hpp
    src/utils/gui2/widgets/root.hpp
    src/utils/gui2/widgets/button.hpp
-   src/utils/gui2/windowmanager.hpp
-   src/utils/gui2/page.hpp
-   src/utils/gui2/style.hpp
-   src/utils/gui2/guitask.hpp
-   src/utils/gui2/view.hpp
 )
 
 set(UTILS_GUI2_SOURCES
@@ -321,22 +363,28 @@ set(CORE_SOURCES
    src/blunted.cpp
 )
 
-set(ALL_HEADERS ${BASE_HEADERS} ${SYSTEMS_COMMON_HEADERS}
-   ${SYSTEMS_GRAPHICS_HEADERS} ${SYSTEMS_AUDIO_HEADERS} ${LOADERS_HEADERS}
-   ${TYPES_HEADERS} ${FRAMEWORK_HEADERS} ${SCENE_HEADERS} ${MANAGERS_HEADERS}
-   ${UTILS_HEADERS} ${UTILS_GUI2_HEADERS} ${CORE_HEADERS}
-)
-
-set(LIBS_HEADERS
+set(LIBS_FASTEVENTS_HEADERS
    src/libs/fastevents/SDLUtils.h
    src/libs/fastevents/trace.h
    src/libs/fastevents/fastevents.h
    src/libs/fastevents/queue.h
+)
+
+set(LIBS_SQLITE3_HEADERS
    src/libs/sqlite3/sqlite3ext.h
    src/libs/sqlite3/sqlite3.h
+)
+
+set(LIBS_HEADERS
    src/libs/fastapprox.h
+)
+
+set(LIBS_GLEE_HEADERS
    src/libs/glee/GLee.h
 )
+
+set(ALL_LIBS_HEADERS ${LIBS_HEADERS} ${LIBS_FASTEVENTS_HEADERS} 
+   ${LIBS_SQLITE3_HEADERS} ${LIBS_GLEE_HEADERS})
 
 set(LIBS_SOURCES
    src/libs/fastevents/fastevents.c

--- a/sources.cmake
+++ b/sources.cmake
@@ -1,0 +1,348 @@
+set(BASE_HEADERS
+   src/base/log.hpp
+   src/base/exception.hpp
+   src/base/utils.hpp
+   src/base/properties.hpp
+   src/base/sdl_surface.hpp
+   src/base/geometry/aabb.hpp
+   src/base/geometry/trianglemeshutils.hpp
+   src/base/geometry/plane.hpp
+   src/base/geometry/triangle.hpp
+   src/base/geometry/line.hpp
+   src/base/math/quaternion.hpp
+   src/base/math/matrix3.hpp
+   src/base/math/matrix4.hpp
+   src/base/math/vector3.hpp
+   src/base/math/bluntmath.hpp
+)
+
+set(BASE_SOURCES
+   src/base/exception.cpp
+   src/base/sdl_surface.cpp
+   src/base/utils.cpp
+   src/base/properties.cpp
+   src/base/log.cpp
+   src/base/geometry/triangle.cpp
+   src/base/geometry/line.cpp
+   src/base/geometry/trianglemeshutils.cpp
+   src/base/geometry/aabb.cpp
+   src/base/geometry/plane.cpp
+   src/base/math/vector3.cpp
+   src/base/math/matrix3.cpp
+   src/base/math/bluntmath.cpp
+   src/base/math/quaternion.cpp
+   src/base/math/matrix4.cpp
+)
+
+set(SYSTEMS_COMMON_HEADERS
+   src/systems/isystemscene.hpp
+   src/systems/isystem.hpp
+   src/systems/isystemtask.hpp
+   src/systems/isystemobject.hpp
+)
+
+set(SYSTEMS_COMMON_SOURCES
+   src/systems/isystemtask.cpp
+)
+
+set(SYSTEMS_GRAPHICS_HEADERS
+   src/systems/graphics/graphics_task.hpp
+   src/systems/graphics/objects/graphics_overlay2d.hpp
+   src/systems/graphics/objects/graphics_camera.hpp
+   src/systems/graphics/objects/graphics_light.hpp
+   src/systems/graphics/objects/graphics_geometry.hpp
+   src/systems/graphics/graphics_scene.hpp
+   src/systems/graphics/graphics_object.hpp
+   src/systems/graphics/resources/vertexbuffer.hpp
+   src/systems/graphics/resources/texture.hpp
+   src/systems/graphics/rendering/interface_renderer3d.hpp
+   src/systems/graphics/rendering/opengl_renderer3d.hpp
+   src/systems/graphics/rendering/r3d_messages.hpp
+   src/systems/graphics/graphics_system.hpp
+)
+
+set(SYSTEMS_GRAPHICS_SOURCES
+   src/systems/graphics/graphics_object.cpp
+   src/systems/graphics/graphics_task.cpp
+   src/systems/graphics/objects/graphics_geometry.cpp
+   src/systems/graphics/objects/graphics_camera.cpp
+   src/systems/graphics/objects/graphics_light.cpp
+   src/systems/graphics/objects/graphics_overlay2d.cpp
+   src/systems/graphics/graphics_scene.cpp
+   src/systems/graphics/resources/vertexbuffer.cpp
+   src/systems/graphics/resources/texture.cpp
+   src/systems/graphics/rendering/r3d_messages.cpp
+   src/systems/graphics/rendering/opengl_renderer3d.cpp
+   src/systems/graphics/graphics_system.cpp
+)
+
+set(SYSTEMS_PHYSICS_HEADERS
+   src/systems/physics/physics_scene.hpp
+   src/systems/physics/physics_object.hpp
+   src/systems/physics/objects/physics_geometry.hpp
+   src/systems/physics/objects/physics_joint.hpp
+   src/systems/physics/wrappers/ode_physics.hpp
+   src/systems/physics/wrappers/interface_physics.hpp
+   src/systems/physics/resources/vertexbuffer.hpp
+   src/systems/physics/physics_system.hpp
+   src/systems/physics/physics_task.hpp
+)
+
+set(SYSTEMS_PHYSICS_SOURCES
+   src/systems/physics/physics_scene.cpp
+   src/systems/physics/physics_task.cpp
+   src/systems/physics/physics_system.cpp
+   src/systems/physics/physics_object.cpp
+   src/systems/physics/objects/physics_joint.cpp
+   src/systems/physics/objects/physics_geometry.cpp
+   src/systems/physics/wrappers/ode_physics.cpp
+   src/systems/physics/resources/vertexbuffer.cpp
+)
+
+set(SYSTEMS_AUDIO_HEADERS
+   src/systems/audio/objects/audio_sound.hpp
+   src/systems/audio/objects/audio_audioreceiver.hpp
+   src/systems/audio/audio_object.hpp
+   src/systems/audio/resources/audio_soundbuffer.hpp
+   src/systems/audio/audio_scene.hpp
+   src/systems/audio/rendering/openal_renderer.hpp
+   src/systems/audio/rendering/interface_audiorenderer.hpp
+   src/systems/audio/rendering/audio_messages.hpp
+   src/systems/audio/audio_system.hpp
+)
+
+set(SYSTEMS_AUDIO_SOURCES
+   src/systems/audio/audio_system.cpp
+   src/systems/audio/audio_scene.cpp
+   src/systems/audio/objects/audio_audioreceiver.cpp
+   src/systems/audio/objects/audio_sound.cpp
+   src/systems/audio/resources/audio_soundbuffer.cpp
+   src/systems/audio/rendering/openal_renderer.cpp
+   src/systems/audio/rendering/audio_messages.cpp
+   src/systems/audio/audio_object.cpp
+)
+
+set(LOADERS_HEADERS
+   src/loaders/aseloader.hpp
+   src/loaders/wavloader.hpp
+   src/loaders/imageloader.hpp
+)
+
+set(LOADERS_SOURCES
+   src/loaders/imageloader.cpp
+   src/loaders/aseloader.cpp
+   src/loaders/wavloader.cpp
+)
+
+set(TYPES_HEADERS
+   src/types/trianglemesh.hpp
+   src/types/subject.hpp
+   src/types/spatial.hpp
+   src/types/iusertask.hpp
+   src/types/lockable.hpp
+   src/types/resource.hpp
+   src/types/material.hpp
+   src/types/observer.hpp
+   src/types/singleton.hpp
+   src/types/interpreter.hpp
+   src/types/refcounted.hpp
+   src/types/command.hpp
+   src/types/loader.hpp
+   src/types/thread.hpp
+   src/types/messagequeue.hpp
+)
+
+set(TYPES_SOURCES
+   src/types/iusertask.cpp
+   src/types/spatial.cpp
+   src/types/refcounted.cpp
+   src/types/trianglemesh.cpp
+   src/types/observer.cpp
+   src/types/command.cpp
+)
+
+set(FRAMEWORK_HEADERS
+   src/framework/workerthread.hpp
+   src/framework/tasksequence.hpp
+   src/framework/scheduler.hpp
+)
+
+set(FRAMEWORK_SOURCES
+   src/framework/workerthread.cpp
+   src/framework/tasksequence.cpp
+   src/framework/scheduler.cpp
+)
+
+set(SCENE_HEADERS
+   src/scene/scene.hpp
+   src/scene/scene2d/scene2d.hpp
+   src/scene/object.hpp
+   src/scene/objectfactory.hpp
+   src/scene/objects/skybox.hpp
+   src/scene/objects/geometry.hpp
+   src/scene/objects/light.hpp
+   src/scene/objects/audioreceiver.hpp
+   src/scene/objects/sound.hpp
+   src/scene/objects/joint.hpp
+   src/scene/objects/image2d.hpp
+   src/scene/objects/camera.hpp
+   src/scene/scene3d/scene3d.hpp
+   src/scene/scene3d/node.hpp
+   src/scene/iscene.hpp
+   src/scene/resources/geometrydata.hpp
+   src/scene/resources/soundbuffer.hpp
+   src/scene/resources/surface.hpp
+)
+
+set(SCENE_SOURCES
+   src/scene/objectfactory.cpp
+   src/scene/scene2d/scene2d.cpp
+   src/scene/scene.cpp
+   src/scene/objects/image2d.cpp
+   src/scene/objects/sound.cpp
+   src/scene/objects/light.cpp
+   src/scene/objects/audioreceiver.cpp
+   src/scene/objects/geometry.cpp
+   src/scene/objects/skybox.cpp
+   src/scene/objects/joint.cpp
+   src/scene/objects/camera.cpp
+   src/scene/scene3d/scene3d.cpp
+   src/scene/scene3d/node.cpp
+   src/scene/object.cpp
+   src/scene/resources/surface.cpp
+   src/scene/resources/soundbuffer.cpp
+   src/scene/resources/geometrydata.cpp
+)
+
+set(MANAGERS_HEADERS
+   src/managers/resourcemanager.hpp
+   src/managers/taskmanager.hpp
+   src/managers/resourcemanagerpool.hpp
+   src/managers/environmentmanager.hpp
+   src/managers/usereventmanager.hpp
+   src/managers/scenemanager.hpp
+   src/managers/systemmanager.hpp
+)
+
+set(MANAGERS_SOURCES
+   src/managers/taskmanager.cpp
+   src/managers/scenemanager.cpp
+   src/managers/resourcemanagerpool.cpp
+   src/managers/usereventmanager.cpp
+   src/managers/environmentmanager.cpp
+   src/managers/systemmanager.cpp
+)
+
+set(UTILS_HEADERS
+   src/utils/animation.hpp
+   src/utils/objectloader.hpp
+   src/utils/database.hpp
+   src/utils/xmlloader.hpp
+   src/utils/splitgeometry.hpp
+   src/utils/orbitcamera.hpp
+   src/utils/text2d.hpp
+   src/utils/directoryparser.hpp
+   src/utils/animationextensions/animationextension.hpp
+   src/utils/animationextensions/footballanimationextension.hpp
+   src/utils/threadhud.hpp
+   src/utils/console.hpp
+)
+
+set(UTILS_SOURCES
+   src/utils/database.cpp
+   src/utils/text2d.cpp
+   src/utils/orbitcamera.cpp
+   src/utils/animation.cpp
+   src/utils/splitgeometry.cpp
+   src/utils/objectloader.cpp
+   src/utils/directoryparser.cpp
+   src/utils/threadhud.cpp
+   src/utils/xmlloader.cpp
+   src/utils/animationextensions/footballanimationextension.cpp
+   src/utils/console.cpp
+)
+
+set(UTILS_GUI2_HEADERS
+   src/utils/gui2/events.hpp
+   src/utils/gui2/widgets/slider.hpp
+   src/utils/gui2/widgets/image.hpp
+   src/utils/gui2/widgets/dialog.hpp
+   src/utils/gui2/widgets/editline.hpp
+   src/utils/gui2/widgets/caption.hpp
+   src/utils/gui2/widgets/filebrowser.hpp
+   src/utils/gui2/widgets/pulldown.hpp
+   src/utils/gui2/widgets/frame.hpp
+   src/utils/gui2/widgets/iconselector.hpp
+   src/utils/gui2/widgets/capturekey.hpp
+   src/utils/gui2/widgets/scrollbar.hpp
+   src/utils/gui2/widgets/grid.hpp
+   src/utils/gui2/widgets/text.hpp
+   src/utils/gui2/widgets/menu.hpp
+   src/utils/gui2/widgets/root.hpp
+   src/utils/gui2/widgets/button.hpp
+   src/utils/gui2/windowmanager.hpp
+   src/utils/gui2/page.hpp
+   src/utils/gui2/style.hpp
+   src/utils/gui2/guitask.hpp
+   src/utils/gui2/view.hpp
+)
+
+set(UTILS_GUI2_SOURCES
+   src/utils/gui2/style.cpp
+   src/utils/gui2/widgets/caption.cpp
+   src/utils/gui2/widgets/menu.cpp
+   src/utils/gui2/widgets/editline.cpp
+   src/utils/gui2/widgets/button.cpp
+   src/utils/gui2/widgets/image.cpp
+   src/utils/gui2/widgets/grid.cpp
+   src/utils/gui2/widgets/root.cpp
+   src/utils/gui2/widgets/iconselector.cpp
+   src/utils/gui2/widgets/frame.cpp
+   src/utils/gui2/widgets/filebrowser.cpp
+   src/utils/gui2/widgets/scrollbar.cpp
+   src/utils/gui2/widgets/capturekey.cpp
+   src/utils/gui2/widgets/text.cpp
+   src/utils/gui2/widgets/slider.cpp
+   src/utils/gui2/widgets/dialog.cpp
+   src/utils/gui2/widgets/pulldown.cpp
+   src/utils/gui2/events.cpp
+   src/utils/gui2/view.cpp
+   src/utils/gui2/windowmanager.cpp
+   src/utils/gui2/guitask.cpp
+   src/utils/gui2/page.cpp
+)
+
+set(CORE_HEADERS
+   src/defines.hpp
+   src/blunted.hpp
+)
+
+set(CORE_SOURCES
+   src/blunted.cpp
+)
+
+set(ALL_HEADERS ${BASE_HEADERS} ${SYSTEMS_COMMON_HEADERS}
+   ${SYSTEMS_GRAPHICS_HEADERS} ${SYSTEMS_AUDIO_HEADERS} ${LOADERS_HEADERS}
+   ${TYPES_HEADERS} ${FRAMEWORK_HEADERS} ${SCENE_HEADERS} ${MANAGERS_HEADERS}
+   ${UTILS_HEADERS} ${UTILS_GUI2_HEADERS} ${CORE_HEADERS}
+)
+
+set(LIBS_HEADERS
+   src/libs/fastevents/SDLUtils.h
+   src/libs/fastevents/trace.h
+   src/libs/fastevents/fastevents.h
+   src/libs/fastevents/queue.h
+   src/libs/sqlite3/sqlite3ext.h
+   src/libs/sqlite3/sqlite3.h
+   src/libs/fastapprox.h
+   src/libs/glee/GLee.h
+)
+
+set(LIBS_SOURCES
+   src/libs/fastevents/fastevents.c
+   src/libs/fastevents/trace.c
+   src/libs/fastevents/SDLUtils.c
+   src/libs/sqlite3/sqlite3.c
+   src/libs/glee/GLee.c
+)
+


### PR DESCRIPTION
This add support for building and installing the library with cmake. It will build a static library and install it with its header files accordingly.

The main files are CMakeLists.txt where the build process is defined and sources.cmake, which contains the files to build. At the CMakeModules there are some Find scripts to libraries not yet on default CMake installation (in case SDL_gfx and SGE).

It won't build the physics part, as it isn't necessary to GameplayFootbal.

The build instructions for Unix-like systems are:

`mkdir build`
`cd build`
`cmake ..`
`make -j8`
 `make install`

The make install is necessary to the build process on GameplayFootball be able to locate the library and link with it.

I didn't tested on windows (I don't have one to test). There you should call cmake with -G something to generate the VisualStudio projects and compile inside that program.
